### PR TITLE
Spark Max Implementation

### DIFF
--- a/lib/include/rmb/motorcontrol/SparkMax/SparkMaxVelocityController.h
+++ b/lib/include/rmb/motorcontrol/SparkMax/SparkMaxVelocityController.h
@@ -45,8 +45,8 @@ namespace rmb {
     void setVelocity(Velocity_t velocity) override;
     Velocity_t getVelocity() override;
 
-    inline void setInverted(bool inverted) override { sparkMax.SetInverted(inverted) };
-    inline bool getInverted() override { return sparkMax.GetInverted() };
+    inline void setInverted(bool inverted) override { sparkMax.SetInverted(inverted); };
+    inline bool getInverted() override { return sparkMax.GetInverted(); };
     inline void disable() override { sparkMax.Disable(); }
     inline void stopMotor() override { sparkMax.StopMotor(); };
 

--- a/lib/include/rmb/motorcontrol/SparkMax/SparkMaxVelocityController.h
+++ b/lib/include/rmb/motorcontrol/SparkMax/SparkMaxVelocityController.h
@@ -29,7 +29,7 @@ namespace rmb {
     // raw velocity is in rpm. 1 rotation * 2pi rad = 2pi rad
     using RawUnit   = typename units::unit<std::ratio<2>, units::radians, std::ratio<1>>;
     using RawUnit_t = typename units::unit_t<RawUnit>;
-    using RawVelocity   = typename units::compound_unit<RawUnit, units::inverse<units::seconds>>;
+    using RawVelocity   = typename units::compound_unit<RawUnit, units::inverse<units::minutes>>;
     using RawVelocity_t = typename units::unit_t<RawVelocity>;
     
     struct PIDConfig {

--- a/lib/include/rmb/motorcontrol/SparkMax/SparkMaxVelocityController.h
+++ b/lib/include/rmb/motorcontrol/SparkMax/SparkMaxVelocityController.h
@@ -11,7 +11,7 @@
 namespace rmb {
   // an abstraction over the SparkMax motor controller
   template <typename DistanceUnit>
-  class SparkMaxVelocityController : public VelocityController<DistanceUnit>, public frc::MotorSafety{
+  class SparkMaxVelocityController : public VelocityController<DistanceUnit> {
   public:
 
     using Distance_t   = typename VelocityController<DistanceUnit>::Distance_t;
@@ -45,7 +45,13 @@ namespace rmb {
     void setVelocity(Velocity_t velocity) override;
     Velocity_t getVelocity() override;
 
+    inline void setInverted(bool inverted) override { sparkMax.SetInverted(inverted) };
+    inline bool getInverted() override { return sparkMax.GetInverted() };
+    inline void disable() override { sparkMax.Disable(); }
+    inline void stopMotor() override { sparkMax.StopMotor(); };
+
   private:
+
     rev::CANSparkMax sparkMax;
     rev::SparkMaxRelativeEncoder sparkMaxEncoder;
     rev::SparkMaxPIDController sparkMaxPIDController;

--- a/lib/include/rmb/motorcontrol/SparkMax/SparkMaxVelocityController.h
+++ b/lib/include/rmb/motorcontrol/SparkMax/SparkMaxVelocityController.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <units/base.h>
+#include <units/angle.h>
+
+#include <rev/CANSparkMax.h>
+#include "rmb/motorcontrol/VelocityController.h"
+
+#include <frc/MotorSafety.h>
+
+namespace rmb {
+  // an abstraction over the SparkMax motor controller
+  template <typename DistanceUnit>
+  class SparkMaxVelocityController : public VelocityController<DistanceUnit>, public frc::MotorSafety{
+  public:
+
+    using Distance_t   = typename VelocityController<DistanceUnit>::Distance_t;
+
+    using VeloctyUnit = typename VelocityController<DistanceUnit>::VelocityUnit;
+    using Velocity_t  = typename VelocityController<DistanceUnit>::Velocity_t;
+
+    using AccelerationUnit = typename VelocityController<DistanceUnit>::AccelerationUnit;
+    using Acceleration_t   = typename VelocityController<DistanceUnit>::Acceleration_t;
+
+    // user defined conversion factor
+    using ConversionUnit   = typename units::compound_unit<DistanceUnit, units::inverse<units::radians>>;
+    using ConversionUnit_t = typename units::unit_t<ConversionUnit>;
+
+    // raw velocity is in rpm. 1 rotation * 2pi rad = 2pi rad
+    using RawUnit   = typename units::unit<std::ratio<2>, units::radians, std::ratio<1>>;
+    using RawUnit_t = typename units::unit_t<RawUnit>;
+    using RawVelocity   = typename units::compound_unit<RawUnit, units::inverse<units::seconds>>;
+    using RawVelocity_t = typename units::unit_t<RawVelocity>;
+    
+    struct PIDConfig {
+      double p, i, d, f;
+      double iZone, iMaxAccumulator;
+      Velocity_t allowableError;
+      double maxOutput, minOutput;
+    };
+
+    SparkMaxVelocityController(int deviceID);
+    SparkMaxVelocityController(int deviceID, const PIDConfig& config, ConversionUnit_t conversionUnit);
+
+    void setVelocity(Velocity_t velocity) override;
+    Velocity_t getVelocity() override;
+
+  private:
+    rev::CANSparkMax sparkMax;
+    rev::SparkMaxRelativeEncoder sparkMaxEncoder;
+    rev::SparkMaxPIDController sparkMaxPIDController;
+    ConversionUnit_t conversion;
+  };
+} // namespace rmb

--- a/lib/src/motorcontrol/SparkMax/SparkMaxVelocityController.cpp
+++ b/lib/src/motorcontrol/SparkMax/SparkMaxVelocityController.cpp
@@ -1,0 +1,49 @@
+#include <rmb/motorcontrol/SparkMax/SparkMaxVelocityController.h>
+
+namespace rmb {
+
+  template <typename U>
+  SparkMaxVelocityController<U>::SparkMaxVelocityController(int deviceID) : 
+                                                            sparkMax(deviceID, rev::CANSparkMax::MotorType::kBrushless) {
+    sparkMaxEncoder = sparkMax.GetEncoder();
+    sparkMaxPIDController = sparkMax.GetPIDController();
+
+  }
+
+  template <typename U>
+  SparkMaxVelocityController<U>::SparkMaxVelocityController(
+                                                            int deviceID, 
+                                                            const PIDConfig& config, 
+                                                            ConversionUnit_t conversionUnit
+                                                            ) : 
+                                                            sparkMax(
+                                                                    deviceID, 
+                                                                    rev::CANSparkMax::MotorType::kBrushless
+                                                                    ), conversion(conversionUnit) {
+    
+    sparkMaxEncoder = sparkMax.GetEncoder();
+    sparkMaxPIDController = sparkMax.GetPIDController();
+
+    sparkMaxPIDController.SetP(config.p);
+    sparkMaxPIDController.SetI(config.i);
+    sparkMaxPIDController.SetD(config.d);
+    sparkMaxPIDController.SetFF(config.f);
+    sparkMaxPIDController.SetIZone(config.iZone);
+    sparkMaxPIDController.SetIMaxAccum(config.iMaxAccumulator);
+    // still need to implement closed loop error
+    sparkMaxPIDController.SetOutputRange(config.minOutput);
+    
+  }
+
+  template <typename U>
+  void SparkMaxVelocityController<U>::setVelocity(Velocity_t velocity) {
+    double setPoint = RawVelocity_t(velocity / conversion).to<double>;
+    sparkMaxPIDController.SetReference(setPoint, rev::ControlType::kVelocity);
+  }
+
+  template <typename U>
+  typename SparkMaxVelocityController<U>::Velocity_t SparkMaxVelocityController<U>::getVelocity() {
+    return Velocity_t(RawVelocity_t(sparkMaxEncoder.GetVelocity()) * conversion);
+  }
+
+} // namespace rmb


### PR DESCRIPTION
This is the first edition of the SparkMax velocity controller abstraction. I checked the math in the conversions and it seems to work out alright assuming the multiplication in getVelocity() works out. However, it would be great if somebody could give it a read-through. 

A little on the SparkMaxes: Units are done in RPM. I chose the base units of RawUnit to be radians as it is a pretty easy conversion 1 rotation * 2pi = 2pi rad.