### PR TITLE
Removed subclassing from frc::MotorSaftey

### DIFF
--- a/lib/include/rmb/motorcontrol/VelocityController.h
+++ b/lib/include/rmb/motorcontrol/VelocityController.h
@@ -17,9 +17,7 @@ namespace rmb {
     virtual void setVelocity(Velocity_t velocity) = 0;
     virtual Velocity_t getVelocity() = 0;
 
-    virtual void setInverted(bool invetred) = 0;
+    virtual void setInverted(bool inverted) = 0;
     virtual bool getInverted() const = 0;
-    virtual void disable() = 0;
-    virtual void stopMotor() = 0;
   };
 } // rmb namespace

--- a/lib/include/rmb/motorcontrol/talon/TalonFXVelocityController.h
+++ b/lib/include/rmb/motorcontrol/talon/TalonFXVelocityController.h
@@ -40,7 +40,7 @@ namespace rmb {
       void setVelocity(Velocity_t velocity) override;
       Velocity_t getVelocity() override;
 
-      inline void setInverted(bool inverted) override { talonFX.SetInverted(invetred); }
+      inline void setInverted(bool inverted) override { talonFX.SetInverted(inverted); }
       inline bool getInverted() override { return talonFX.GetInverted(); }
 
     private:

--- a/lib/include/rmb/motorcontrol/talon/TalonFXVelocityController.h
+++ b/lib/include/rmb/motorcontrol/talon/TalonFXVelocityController.h
@@ -10,7 +10,7 @@
 
 namespace rmb {
   template<typename DistanceUnit>
-  class TalonFXVelocityController: public VelocityController<DistanceUnit>, public frc::MotorSafety {
+  class TalonFXVelocityController: public VelocityController<DistanceUnit> {
     public:
       using Distance_t =   typename VelocityController<DistanceUnit>::Distance_t;
       using VelocityUnit = typename VelocityController<DistanceUnit>::VelocityUnit;
@@ -40,20 +40,8 @@ namespace rmb {
       void setVelocity(Velocity_t velocity) override;
       Velocity_t getVelocity() override;
 
-      inline void setInverted(bool invetred) override { talonFX.SetInverted(invetred); }
+      inline void setInverted(bool inverted) override { talonFX.SetInverted(invetred); }
       inline bool getInverted() override { return talonFX.GetInverted(); }
-      inline void disable() override { talonFX.Disable(); }	
-
-
-      inline void Feed() override { talonFX.Feed(); }
-      inline void SetExpiration(units::second_t expirationTime) override { talonFX.SetExpiration(expirationTime); }
-      inline units::second_t GetExpiration() const override { return talonFX.GetExpiration(); }
-      inline bool IsAlive() const override { return talonFX.IsAlive(); }
-      inline void SetSafetyEnabled(bool enabled) override { talonFX.SetSafetyEnabled(enabled); }
-      inline bool IsSafetyEnabled() const override { return talonFX.IsSafetyEnabled(); }
-      inline void Check() override { talonFX.Check(); }
-      inline void StopMotor() override { talonFX.StopMotor(); }
-      inline std::string GetDescription() override { return talonFX.GetDescription(); }
 
     private:
       ctre::phoenix::motorcontrol::can::WPI_TalonFX talonFX;

--- a/lib/include/rmb/motorcontrol/talon/TalonSRXVelocityController.h
+++ b/lib/include/rmb/motorcontrol/talon/TalonSRXVelocityController.h
@@ -40,7 +40,7 @@ namespace rmb {
       void setVelocity(Velocity_t velocity) override;
       Velocity_t getVelocity() override;
 
-      inline void setInverted(bool inverted) override { talonSRX.SetInverted(invetred); }
+      inline void setInverted(bool inverted) override { talonSRX.SetInverted(inverted); }
       inline bool getInverted() override { return talonSRX.GetInverted(); }
 
     private:

--- a/lib/include/rmb/motorcontrol/talon/TalonSRXVelocityController.h
+++ b/lib/include/rmb/motorcontrol/talon/TalonSRXVelocityController.h
@@ -10,7 +10,7 @@
 
 namespace rmb {
   template<typename DistanceUnit>
-  class TalonSRXVelocityController: public VelocityController<DistanceUnit>, public frc::MotorSafety {
+  class TalonSRXVelocityController: public VelocityController<DistanceUnit> {
     public:
       using Distance_t =   typename VelocityController<DistanceUnit>::Distance_t;
       using VelocityUnit = typename VelocityController<DistanceUnit>::VelocityUnit;
@@ -40,21 +40,8 @@ namespace rmb {
       void setVelocity(Velocity_t velocity) override;
       Velocity_t getVelocity() override;
 
-      inline void setInverted(bool invetred) override { talonSRX.SetInverted(invetred); }
+      inline void setInverted(bool inverted) override { talonSRX.SetInverted(invetred); }
       inline bool getInverted() override { return talonSRX.GetInverted(); }
-      inline void disable() override { talonSRX.Disable(); }
-      inline void stopMotor() override { talonSRX.StopMotor(); }
-
-
-      inline void Feed() override { talonSRX.Feed(); }
-      inline void SetExpiration(units::second_t expirationTime) override { talonSRX.SetExpiration(expirationTime); }
-      inline units::second_t GetExpiration() const override { return talonSRX.GetExpiration(); }
-      inline bool IsAlive() const override { return talonSRX.IsAlive(); }
-      inline void SetSafetyEnabled(bool enabled) override { talonSRX.SetSafetyEnabled(enabled); }
-      inline bool IsSafetyEnabled() const override { return talonSRX.IsSafetyEnabled(); }
-      inline void Check() override { talonSRX.Check(); }
-      inline void StopMotor() override { talonSRX.StopMotor(); }
-      inline std::string GetDescription() override { return talonSRX.GetDescription(); }
 
     private:
       ctre::phoenix::motorcontrol::can::WPI_TalonSRX talonSRX;


### PR DESCRIPTION
Just what it says in the name, although I left the invert functions since they will be useful.