### PR TITLE
Spark max position controller implementation

### DIFF
--- a/lib/include/rmb/motorcontrol/PositionController.h
+++ b/lib/include/rmb/motorcontrol/PositionController.h
@@ -16,8 +16,8 @@ namespace rmb {
       using Acceleration = units::compound_unit<Velocity, units::inverse<units::seconds>>;
       using Acceleration_t = units::unit_t<Acceleration>;
 
-      virtual void restRefrence(Distance_t position) = 0;
-      virtual void setMaxPositon(Distance_t max) = 0;
+      virtual void resetRefrence(Distance_t position) = 0;
+      virtual void setMaxPosition(Distance_t max) = 0;
       virtual Distance_t getMaxPosition() = 0;
       virtual void setMinPosition(Distance_t min) = 0;
       virtual Distance_t getMinPosition() = 0;

--- a/lib/include/rmb/motorcontrol/PositionController.h
+++ b/lib/include/rmb/motorcontrol/PositionController.h
@@ -18,7 +18,7 @@ namespace rmb {
 
       virtual void restRefrence(Distance_t position) = 0;
       virtual void setMaxPositon(Distance_t max) = 0;
-      virtual Distance_t getMaxPositon() = 0;
+      virtual Distance_t getMaxPosition() = 0;
       virtual void setMinPosition(Distance_t min) = 0;
       virtual Distance_t getMinPosition() = 0;
 

--- a/lib/include/rmb/motorcontrol/PositionController.h
+++ b/lib/include/rmb/motorcontrol/PositionController.h
@@ -26,7 +26,7 @@ namespace rmb {
       virtual Distance_t getPosition() = 0;
       virtual Velocity_t getVelocity() = 0;
 
-      virtual void setInverted(bool invetred) = 0;
+      virtual void setInverted(bool inverted) = 0;
       virtual bool getInverted() const = 0;
       virtual void disable() = 0;
       virtual void stopMotor() = 0;

--- a/lib/include/rmb/motorcontrol/SparkMax/SparkMaxPositionController.h
+++ b/lib/include/rmb/motorcontrol/SparkMax/SparkMaxPositionController.h
@@ -1,0 +1,56 @@
+#include <units/base.h>
+#include <units/angle.h>
+#include <units/time.h>
+
+#include <rev/CANSparkMax.h>
+
+#include <rmb/motorcontrol/PositionController.h>
+
+namespace rmb {
+  template <typename DistanceUnit>
+  class SparkMaxPositionController : PositionController<DistanceUnit> {
+  public:
+
+    using Distance_t   = typename PositionController<DistanceUnit>::Distance_t;
+
+    using VeloctyUnit = typename PositionController<DistanceUnit>::VelocityUnit;
+    using Velocity_t  = typename PositionController<DistanceUnit>::Velocity_t;
+
+    // position functions for the spark max take in rotations
+    // 1 rotation * 2pi = 2pi rad
+    using RawUnit       = typename units::unit<std::ratio<2>, units::radians, std::ratio<1>>;
+    using RawUnit_t     = typename units::unit_t<RawUnit>;
+    // velocity is in rpm
+    using RawVelocity   = typename units::compound_unit<RawUnit, units::inverse<units::minutes>>;
+    using RawVelocity_t = typename units::unit_t<RawVelocity>;
+
+    //user defined conversion unit
+    using ConversionUnit   = typename units::compound_unit<DistanceUnit, units::inverse<units::radians>>;
+    using ConversionUnit_t = typename units::unit_t<ConversionUnit>;
+
+    struct PIDConfig {
+      double p, i, d, f;
+      double iZone, iMaxAccumulator;
+      double maxOutput, minOutput;
+    };
+
+    SparkMaxPositionController(int deviceID);
+    SparkMaxPositionController(int deviceID, const PIDConfig& pidConfig, ConversionUnit_t conversion = 1);
+
+    void setPosition(Distance_t position) override;
+    Distance_t getPosition() override;
+    Velocity_t getVelocity() override;
+
+    inline void setInverted(bool inverted) override { sparkMax.SetInverted(inverted); };
+    inline bool getInverted() const override { return sparkMax.GetInverted(); };
+    inline void disable() override { sparkMax.Disable(); };
+    inline void stopMotor() override { sparkMax.StopMotor(); };
+
+  private:
+    rev::CANSparkMax sparkMax;
+    rev::RelativeEncoder sparkMaxEncoder;
+    rev::SparkMaxPIDController sparkMaxPIDController;
+
+    ConversionUnit_t conversion;
+  };
+} // namespace rmb

--- a/lib/include/rmb/motorcontrol/SparkMax/SparkMaxPositionController.h
+++ b/lib/include/rmb/motorcontrol/SparkMax/SparkMaxPositionController.h
@@ -6,36 +6,37 @@
 
 #include <rmb/motorcontrol/PositionController.h>
 
-namespace rmb {
+namespace rmb
+{
   template <typename DistanceUnit>
   class SparkMaxPositionController : PositionController<DistanceUnit> {
   public:
-
-    using Distance_t   = typename PositionController<DistanceUnit>::Distance_t;
+    using Distance_t = typename PositionController<DistanceUnit>::Distance_t;
 
     using VeloctyUnit = typename PositionController<DistanceUnit>::VelocityUnit;
-    using Velocity_t  = typename PositionController<DistanceUnit>::Velocity_t;
+    using Velocity_t = typename PositionController<DistanceUnit>::Velocity_t;
 
     // position functions for the spark max take in rotations
     // 1 rotation * 2pi = 2pi rad
-    using RawUnit       = typename units::unit<std::ratio<2>, units::radians, std::ratio<1>>;
-    using RawUnit_t     = typename units::unit_t<RawUnit>;
+    using RawUnit = typename units::unit<std::ratio<2>, units::radians, std::ratio<1>>;
+    using RawUnit_t = typename units::unit_t<RawUnit>;
     // velocity is in rpm
-    using RawVelocity   = typename units::compound_unit<RawUnit, units::inverse<units::minutes>>;
+    using RawVelocity = typename units::compound_unit<RawUnit, units::inverse<units::minutes>>;
     using RawVelocity_t = typename units::unit_t<RawVelocity>;
 
-    //user defined conversion unit
-    using ConversionUnit   = typename units::compound_unit<DistanceUnit, units::inverse<units::radians>>;
+    // user defined conversion unit
+    using ConversionUnit = typename units::compound_unit<DistanceUnit, units::inverse<units::radians>>;
     using ConversionUnit_t = typename units::unit_t<ConversionUnit>;
 
-    struct PIDConfig {
+    struct PIDConfig
+    {
       double p, i, d, f;
       double iZone, iMaxAccumulator;
       double maxOutput, minOutput;
     };
 
     SparkMaxPositionController(int deviceID);
-    SparkMaxPositionController(int deviceID, const PIDConfig& pidConfig, ConversionUnit_t conversion = 1);
+    SparkMaxPositionController(int deviceID, const PIDConfig &pidConfig, ConversionUnit_t conversion = 1);
 
     void setPosition(Distance_t position) override;
     Distance_t getPosition() override;
@@ -46,11 +47,21 @@ namespace rmb {
     inline void disable() override { sparkMax.Disable(); };
     inline void stopMotor() override { sparkMax.StopMotor(); };
 
+    void resetRefrence(Distance_t position) override;
+    void setMaxPosition(Distance_t max) override;
+    Distance_t getMaxPosition() override;
+    void setMinPosition(Distance_t min) override;
+    Distance_t getMinPosition() override;
+
   private:
     rev::CANSparkMax sparkMax;
     rev::RelativeEncoder sparkMaxEncoder;
     rev::SparkMaxPIDController sparkMaxPIDController;
 
     ConversionUnit_t conversion;
+
+    RawUnit_t maxPosition = 1;
+    RawUnit_t minPosition = -1;
+    
   };
 } // namespace rmb

--- a/lib/include/rmb/motorcontrol/SparkMax/SparkMaxVelocityController.h
+++ b/lib/include/rmb/motorcontrol/SparkMax/SparkMaxVelocityController.h
@@ -40,7 +40,7 @@ namespace rmb {
     };
 
     SparkMaxVelocityController(int deviceID);
-    SparkMaxVelocityController(int deviceID, const PIDConfig& config, ConversionUnit_t conversionUnit);
+    SparkMaxVelocityController(int deviceID, const PIDConfig& config, ConversionUnit_t conversionUnit = 1);
 
     void setVelocity(Velocity_t velocity) override;
     Velocity_t getVelocity() override;

--- a/lib/src/motorcontrol/SparkMax/SparkMaxPositionController.cpp
+++ b/lib/src/motorcontrol/SparkMax/SparkMaxPositionController.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <rmb/motorcontrol/SparkMax/SparkMaxPositionController.h>
 
 template <typename U>
@@ -32,15 +33,43 @@ rmb::SparkMaxPositionController<U>::SparkMaxPositionController(
 template <typename U>
 void rmb::SparkMaxPositionController<U>::setPosition(Distance_t position) {
   double setPoint = RawUnit_t(position / conversion).to<double>;
+  std::clamp<double>(setPoint, minPosition.to<double>(), maxPosition.to<double>());
   sparkMaxPIDController.SetReference(setPoint, rev::ControlType::kPosition);
 }
 
 template <typename U>
 typename rmb::SparkMaxPositionController<U>::Distance_t rmb::SparkMaxPositionController<U>::getPosition() {
-  return Distance_t(RawUnit_t(sparkMaxEncoder.GetPosition()) * conversion);
+  RawUnit_t val = RawUnit_t(sparkMaxEncoder.GetPosition());
+  std::clamp<RawUnit_t>(val, minPosition, maxPosition);
+  return Velocity_t(val * conversion);
 }
 
 template <typename U>
 typename rmb::SparkMaxPositionController<U>::Velocity_t rmb::SparkMaxPositionController<U>::getVelocity() {
   return Velocity_t(RawVelocity_t(sparkMaxEncoder.GetVelocity()) * conversion);
+}
+
+template <typename U>
+void rmb::SparkMaxPositionController<U>::resetRefrence(Distance_t distance) {
+  sparkMaxEncoder.SetPosition(RawUnit_t(distance / conversion).to<double>());
+}
+
+template <typename U>
+void rmb::SparkMaxPositionController<U>::setMaxPosition(Distance_t max) {
+  maxPosition = RawUnit_t(max / conversion);
+}
+
+template <typename U>
+typename rmb::SparkMaxPositionController<U>::Distance_t rmb::SparkMaxPositionController<U>::getMaxPosition() {
+  return Distance_t(maxPosition * conversion);
+}
+
+template <typename U>
+void rmb::SparkMaxPositionController<U>::setMinPosition(Distance_t min) {
+  minPosition = RawUnit_t(min / conversion);
+}
+
+template <typename U>
+typename rmb::SparkMaxPositionController<U>::Distance_t rmb::SparkMaxPositionController<U>::getMinPosition() {
+  return Distance_t(minPosition * conversion);  
 }

--- a/lib/src/motorcontrol/SparkMax/SparkMaxPositionController.cpp
+++ b/lib/src/motorcontrol/SparkMax/SparkMaxPositionController.cpp
@@ -1,0 +1,46 @@
+#include <rmb/motorcontrol/SparkMax/SparkMaxPositionController.h>
+
+template <typename U>
+rmb::SparkMaxPositionController<U>::SparkMaxPositionController(int deviceID) {
+  sparkMax = rev::CANSparkMax{deviceID, rev::CANSparkMax::MotorType::kBrushless};
+  sparkMaxEncoder = sparkMax.GetEncoder();
+  sparkMaxPIDController = sparkMax.GetPIDController();
+
+}
+
+template <typename U>
+rmb::SparkMaxPositionController<U>::SparkMaxPositionController(
+                                                              int deviceID, 
+                                                              const PIDConfig& config, 
+                                                              ConversionUnit_t conversionFactor
+                                                              ) : conversion(conversionFactor) {
+  
+  sparkMax = rev::CANSparkMax{deviceID, rev::CANSparkMax::MotorType::kBrushless};
+  sparkMaxEncoder = sparkMax.GetEncoder();
+  sparkMaxPIDController = sparkMax.GetPIDController();
+
+  //configure pid consts
+  sparkMaxPIDController.SetP(config.p);
+  sparkMaxPIDController.SetI(config.i);
+  sparkMaxPIDController.SetD(config.d);
+  sparkMaxPIDController.SetFF(config.f);
+  sparkMaxPIDController.SetIZone(config.iZone);
+  sparkMaxPIDController.SetIMaxAccum(config.iMaxAccumulator);
+  sparkMaxPIDController.SetOutputRange(config.minOutput);
+}
+
+template <typename U>
+void rmb::SparkMaxPositionController<U>::setPosition(Distance_t position) {
+  double setPoint = RawUnit_t(position / conversion).to<double>;
+  sparkMaxPIDController.SetReference(setPoint, rev::ControlType::kPosition);
+}
+
+template <typename U>
+typename rmb::SparkMaxPositionController<U>::Distance_t rmb::SparkMaxPositionController<U>::getPosition() {
+  return Distance_t(RawUnit_t(sparkMaxEncoder.GetPosition()) * conversion);
+}
+
+template <typename U>
+typename rmb::SparkMaxPositionController<U>::Velocity_t rmb::SparkMaxPositionController<U>::getVelocity() {
+  return Velocity_t(RawVelocity_t(sparkMaxEncoder.GetVelocity()) * conversion);
+}


### PR DESCRIPTION
There was no function to set the min and max position of the encoder provided by rev:: so I implemented this using std::clamp. However, if there actually is a function to implement this, please let me know.