### PR TITLE
Fix initialization order warnings in MecanumDrive class

### DIFF
--- a/lib/include/rmb/drive/HolonomicTrajectoryCommand.h
+++ b/lib/include/rmb/drive/HolonomicTrajectoryCommand.h
@@ -19,8 +19,8 @@ namespace rmb {
         bool IsFinished();
       private:
         frc::Trajectory trajectory;
-        frc::HolonomicDriveController driveController;
         HolonomicDrive& drive;
+        frc::HolonomicDriveController driveController;
         frc::Timer timer;
   };
 }

--- a/lib/include/rmb/drive/MecanumDrive.h
+++ b/lib/include/rmb/drive/MecanumDrive.h
@@ -18,9 +18,9 @@ namespace rmb {
                    VelocityController<units::meters>& rearLeft,
                    VelocityController<units::meters>& rearRight,
                    frc::MecanumDriveKinematics kinematics,
+                   frc::Gyro& gyro,
                    units::meters_per_second_t maxVelocity,
-                   units::radians_per_second_t maxRotVelocity,
-                   frc::Gyro& gyro);
+                   units::radians_per_second_t maxRotVelocity);
 
       // Functions for moving the robot
       void driveWheelSpeeds(frc::MecanumDriveWheelSpeeds wheelSpeeds);

--- a/lib/src/drive/MecanumDrive.cpp
+++ b/lib/src/drive/MecanumDrive.cpp
@@ -6,12 +6,13 @@ namespace rmb {
                              VelocityController<units::meters>& rl,
                              VelocityController<units::meters>& rr,
                              frc::MecanumDriveKinematics k,
+                             frc::Gyro& g,
                              units::meters_per_second_t maxVel,
-                             units::radians_per_second_t maxRotVel,
-                             frc::Gyro& g) :
-                             frontLeft(fl), frontRight(fr), rearLeft(rl), rearRight(rr),
-                             kinematics(k), maxVelocity(maxVel), maxRotVelocity(maxRotVel),
-                             gyro(g), odometry(kinematics, gyro.GetRotation2d()) {}
+                             units::radians_per_second_t maxRotVel) :
+                             frontLeft(fl), frontRight(fr), rearLeft(rl),
+                             rearRight(rr), kinematics(k), gyro(g),
+                             odometry(kinematics, gyro.GetRotation2d()),
+                             maxVelocity(maxVel), maxRotVelocity(maxRotVel) {}
 
   void MecanumDrive::driveWheelSpeeds(frc::MecanumDriveWheelSpeeds wheelSpeeds) {
     // Set velocity for each individual wheel


### PR DESCRIPTION
Fixes issue #27

Implemented:
- [x] Reordering of initializer list to match that of the header file (Mecanum)
- [x] Reordering of initializer list to match that of the header file (Holonomic) 