### PR TITLE
Separated odometry into it's own class

### DIFF
--- a/lib/include/rmb/drive/HolonomicDrive.h
+++ b/lib/include/rmb/drive/HolonomicDrive.h
@@ -10,17 +10,15 @@
 namespace rmb {
   class HolonomicDrive {
    public:
-    virtual void driveChassisSpeeds(frc::ChassisSpeeds chassisSpeeds, 
-                                    frc::Translation2d centerofRotation = frc::Translation2d()) = 0;
+    virtual void driveChassisSpeeds(const frc::ChassisSpeeds& chassisSpeeds, 
+                                    const frc::Translation2d& centerofRotation = frc::Translation2d()) = 0;
+    
+    virtual frc::ChassisSpeeds getChassisSpeeds() const = 0;
     
     virtual void driveCartesian(double ySpeed, double xSpeed, double zRotation);
     virtual void drivePolar(double magnitude, double angle, double zRotation);
 
-    virtual units::meters_per_second_t getMaxVel() = 0;
-    virtual units::radians_per_second_t getMaxRotVel() = 0;
-
-    virtual const frc::Pose2d& getPose() = 0;
-    virtual const frc::Pose2d& updatePose() = 0;
-    virtual void resetPose() = 0;
+    virtual units::meters_per_second_t getMaxVel() const = 0;
+    virtual units::radians_per_second_t getMaxRotVel() const = 0;
   };
 } // rmb namespace

--- a/lib/include/rmb/drive/HolonomicDriveOdometry.h
+++ b/lib/include/rmb/drive/HolonomicDriveOdometry.h
@@ -1,0 +1,13 @@
+
+#pragma once
+
+#include <frc/geometry/Pose2d.h>
+
+namespace rmb {
+  class HolonomicDriveOdometry {
+      public:
+        virtual const frc::Pose2d& getPose() const = 0;
+        virtual const frc::Pose2d& updatePose() = 0;
+        virtual void resetPose(const frc::Pose2d& pose) = 0;
+  };
+}

--- a/lib/include/rmb/drive/HolonomicTrajectoryCommand.h
+++ b/lib/include/rmb/drive/HolonomicTrajectoryCommand.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <frc/trajectory/Trajectory.h>
@@ -6,21 +7,23 @@
 #include <frc/controller/HolonomicDriveController.h>
 #include <frc/Timer.h>
 
-#include "HolonomicDrive.h"
+#include "rmb/drive/HolonomicDrive.h"
+#include "rmb/drive/HolonomicDriveOdometry.h"
 
 
 namespace rmb {
   class HolonomicTrajectoryCommand : public frc2::CommandHelper<frc2::CommandBase, HolonomicTrajectoryCommand> {
       public:
-        HolonomicTrajectoryCommand(frc::Trajectory trajectory, HolonomicDrive& drive, frc::HolonomicDriveController driveController);
+        HolonomicTrajectoryCommand(const frc::Trajectory& trajectory, HolonomicDrive& drive, const HolonomicDriveOdometry& odometry, frc::HolonomicDriveController& driveController);
         void Initialize();
         void Execute();
         void End(bool interrupted);
         bool IsFinished();
       private:
-        frc::Trajectory trajectory;
+        const frc::Trajectory& trajectory;
         HolonomicDrive& drive;
-        frc::HolonomicDriveController driveController;
+        const HolonomicDriveOdometry& odometry;
+        frc::HolonomicDriveController& driveController;
         frc::Timer timer;
   };
 }

--- a/lib/include/rmb/drive/MecanumDrive.h
+++ b/lib/include/rmb/drive/MecanumDrive.h
@@ -6,7 +6,7 @@
 #include <frc/kinematics/MecanumDriveOdometry.h>
 #include <AHRS.h>
 
-#include "HolonomicDrive.h"
+#include "rmb/drive/HolonomicDrive.h"
 #include "rmb/motorcontrol/VelocityController.h"
 
 namespace rmb {
@@ -17,25 +17,23 @@ namespace rmb {
                    VelocityController<units::meters>& frontRight,
                    VelocityController<units::meters>& rearLeft,
                    VelocityController<units::meters>& rearRight,
-                   frc::MecanumDriveKinematics kinematics,
-                   frc::Gyro& gyro,
+                   const frc::MecanumDriveKinematics& kinematics,
                    units::meters_per_second_t maxVelocity,
                    units::radians_per_second_t maxRotVelocity);
 
       // Functions for moving the robot
-      void driveWheelSpeeds(frc::MecanumDriveWheelSpeeds wheelSpeeds);
-      void driveChassisSpeeds(frc::ChassisSpeeds chassisSpeeds, 
-                              frc::Translation2d centerofRotation = frc::Translation2d());
-      frc::MecanumDriveWheelSpeeds getWheelSpeeds();
+      void driveWheelSpeeds(const frc::MecanumDriveWheelSpeeds& wheelSpeeds);
+
+      frc::MecanumDriveWheelSpeeds getWheelSpeeds() const;
+
+      void driveChassisSpeeds(const frc::ChassisSpeeds& chassisSpeeds, 
+                              const frc::Translation2d& centerofRotation = frc::Translation2d());
+  
+      frc::ChassisSpeeds getChassisSpeeds() const;
       
       // Functions for getting velocity values
-      units::meters_per_second_t getMaxVel() { return maxVelocity; };
-      units::radians_per_second_t getMaxRotVel() { return maxRotVelocity; };
-
-      // Functions dealing with odometry
-      const frc::Pose2d& getPose();
-      const frc::Pose2d& updatePose();
-      void resetPose();
+      units::meters_per_second_t getMaxVel() const { return maxVelocity; };
+      units::radians_per_second_t getMaxRotVel() const { return maxRotVelocity; };
 
     private:
       // Variables for wheels and kinematics (locations)
@@ -43,10 +41,10 @@ namespace rmb {
       VelocityController<units::meters>& frontRight;
       VelocityController<units::meters>& rearLeft;
       VelocityController<units::meters>& rearRight;
-      frc::MecanumDriveKinematics kinematics;
-      frc::Gyro& gyro;
-      frc::MecanumDriveOdometry odometry;
+      const frc::MecanumDriveKinematics& kinematics;
       units::meters_per_second_t maxVelocity;
       units::radians_per_second_t maxRotVelocity;
+
+      friend class MecanumEncoderOdometry;
   };
 } // rmb namespace

--- a/lib/include/rmb/drive/MecanumEncoderOdometry.h
+++ b/lib/include/rmb/drive/MecanumEncoderOdometry.h
@@ -1,0 +1,24 @@
+
+#pragma once
+
+#include <frc/interfaces/Gyro.h>
+
+#include "rmb/drive/HolonomicDrive.h"
+#include "rmb/drive/HolonomicDriveOdometry.h"
+#include "rmb/drive/MecanumDrive.h"
+
+namespace rmb {
+  class MecanumEncoderOdometry : public HolonomicDriveOdometry {
+    public:
+      MecanumEncoderOdometry(MecanumDrive& drive, const frc::Gyro& gyro, const frc::Pose2d& initalPose = frc::Pose2d());
+
+      const frc::Pose2d& getPose() const;
+      const frc::Pose2d& updatePose();
+      void resetPose(const frc::Pose2d& pose);
+
+    private:
+      MecanumDrive& drive;
+      const frc::Gyro& gyro;
+      frc::MecanumDriveOdometry odometry;
+  };
+}

--- a/lib/src/drive/HolonomicTrajectoryCommand.cpp
+++ b/lib/src/drive/HolonomicTrajectoryCommand.cpp
@@ -3,11 +3,12 @@
 #include "rmb/drive/HolonomicTrajectoryCommand.h"
 
 namespace rmb {
-    HolonomicTrajectoryCommand::HolonomicTrajectoryCommand(frc::Trajectory t,
+    HolonomicTrajectoryCommand::HolonomicTrajectoryCommand(const frc::Trajectory& t,
                                                            HolonomicDrive& d,
-                                                           frc::HolonomicDriveController dc) :
-                                                           trajectory(t), drive(d),
-                                                           driveController(dc) {}
+                                                           const HolonomicDriveOdometry& o,
+                                                           frc::HolonomicDriveController& dc) :
+                                                           trajectory(t), drive(d), 
+                                                           odometry(o), driveController(dc) {}
     
     void HolonomicTrajectoryCommand::Initialize() {
         timer.Reset();
@@ -17,7 +18,7 @@ namespace rmb {
     void HolonomicTrajectoryCommand::Execute() {
         units::time::second_t currentTime = units::second_t(timer.Get());
         frc::Trajectory::State desiredState = trajectory.Sample(currentTime);
-        auto targetChassisSpeeds = driveController.Calculate(drive.getPose(), desiredState, trajectory.States().back().pose.Rotation());
+        auto targetChassisSpeeds = driveController.Calculate(odometry.getPose(), desiredState, trajectory.States().back().pose.Rotation());
         drive.driveChassisSpeeds(targetChassisSpeeds);
     }
 

--- a/lib/src/drive/MecanumDrive.cpp
+++ b/lib/src/drive/MecanumDrive.cpp
@@ -1,3 +1,4 @@
+
 #include "rmb/drive/MecanumDrive.h"
 
 namespace rmb {
@@ -5,16 +6,14 @@ namespace rmb {
                              VelocityController<units::meters>& fr,
                              VelocityController<units::meters>& rl,
                              VelocityController<units::meters>& rr,
-                             frc::MecanumDriveKinematics k,
-                             frc::Gyro& g,
+                             const frc::MecanumDriveKinematics& k,
                              units::meters_per_second_t maxVel,
                              units::radians_per_second_t maxRotVel) :
                              frontLeft(fl), frontRight(fr), rearLeft(rl),
-                             rearRight(rr), kinematics(k), gyro(g),
-                             odometry(kinematics, gyro.GetRotation2d()),
+                             rearRight(rr), kinematics(k),
                              maxVelocity(maxVel), maxRotVelocity(maxRotVel) {}
 
-  void MecanumDrive::driveWheelSpeeds(frc::MecanumDriveWheelSpeeds wheelSpeeds) {
+  void MecanumDrive::driveWheelSpeeds(const frc::MecanumDriveWheelSpeeds& wheelSpeeds) {
     // Set velocity for each individual wheel
     frontLeft.setVelocity(wheelSpeeds.frontLeft);
     frontRight.setVelocity(wheelSpeeds.frontRight);
@@ -22,14 +21,7 @@ namespace rmb {
     rearRight.setVelocity(wheelSpeeds.rearRight);
   }
 
-  void MecanumDrive::driveChassisSpeeds(frc::ChassisSpeeds chassisSpeeds, 
-                                        frc::Translation2d centerofRotation) {
-    // Get wheel speeds from kinematics
-    frc::MecanumDriveWheelSpeeds wheelSpeeds = kinematics.ToWheelSpeeds(chassisSpeeds, centerofRotation);
-    driveWheelSpeeds(wheelSpeeds);
-  }
-
-  frc::MecanumDriveWheelSpeeds MecanumDrive::getWheelSpeeds() {
+  frc::MecanumDriveWheelSpeeds MecanumDrive::getWheelSpeeds() const {
     // Return a struct with velocities
     return {
       frontLeft.getVelocity(),
@@ -39,15 +31,14 @@ namespace rmb {
     };
   }
 
-  const frc::Pose2d& MecanumDrive::getPose() {
-    return odometry.GetPose();
+  void MecanumDrive::driveChassisSpeeds(const frc::ChassisSpeeds& chassisSpeeds, 
+                                        const frc::Translation2d& centerofRotation) {
+    // Get wheel speeds from kinematics
+    frc::MecanumDriveWheelSpeeds wheelSpeeds = kinematics.ToWheelSpeeds(chassisSpeeds, centerofRotation);
+    driveWheelSpeeds(wheelSpeeds);
   }
 
-  const frc::Pose2d& MecanumDrive::updatePose() {
-    return odometry.Update(gyro.GetRotation2d(), getWheelSpeeds());
-  }
-
-  void MecanumDrive::resetPose() {
-    odometry.ResetPosition(getPose(), gyro.GetRotation2d());
+  frc::ChassisSpeeds MecanumDrive::getChassisSpeeds() const {
+    return kinematics.ToChassisSpeeds(getWheelSpeeds());
   }
 }

--- a/lib/src/drive/MecanumEncoderOdometry.cpp
+++ b/lib/src/drive/MecanumEncoderOdometry.cpp
@@ -1,0 +1,22 @@
+
+#include "rmb/drive/MecanumEncoderOdometry.h"
+
+namespace rmb {
+  MecanumEncoderOdometry::MecanumEncoderOdometry(MecanumDrive& d, const frc::Gyro& g, const frc::Pose2d& pose) :
+                                                 drive(d), gyro(g), odometry(drive.kinematics, 
+                                                                             gyro.GetRotation2d(), 
+                                                                             pose) {}
+
+  const frc::Pose2d& MecanumEncoderOdometry::getPose() const {
+    return odometry.GetPose();
+  }
+
+  const frc::Pose2d& MecanumEncoderOdometry::updatePose() {
+    return odometry.Update(gyro.GetRotation2d(), drive.getWheelSpeeds());
+  }
+
+  void MecanumEncoderOdometry::resetPose(const frc::Pose2d& pose) {
+    odometry.ResetPosition(pose, gyro.GetRotation2d());
+  }
+
+}


### PR DESCRIPTION
I separated out just for the reasons we had talked about. Odometry is i't own thing should be its own class, since odometry could be found through different methods (ex. Accelerometers instead of encoders).

Additionally, I messed around with which types are references or constant references. In general, these are the rules I went by:

Function Parameters:
 - parameters are passed by reference if they need to be modified
 - large parameters are passed by constant reference (classes with multiple variables)
 - small parameters are passed by value (base types and units)

Function Return Types:
 - return a reference if they need to be modified
 - pass a constant reference if a class  member is being returned
 - otherwise return by value

Member variables:
- use references when referencing another object (ex. Something with physical significant, abstract classes)
- use a constant reference if the above applies, but you are not modifying the variable
- use value if the class itself owns the value

Constructor: Match member variable type

Pointers: When you have no other choice

If this looks accurate, I'll go back and modify other places to a similar format. I don't think it makes that much of a difference, but I thought I'd list them out so we have a common reference (pun intended).

Also ,I started marking functions as constant when they don't modify the class to better align with the above rules.