### PR TITLE
Fiux the flywheel to use the proper units

### DIFF
--- a/src/main/cpp/shooter/ShooterSubsystem.cpp
+++ b/src/main/cpp/shooter/ShooterSubsystem.cpp
@@ -6,27 +6,18 @@
 
 #include "shooter/ShooterSubsystem.h"
 
-ShooterSubsystem::ShooterSubsystem(const units::meter_t wd) : wheelDiameter(wd) {}
-
-void ShooterSubsystem::spinTo(units::angular_velocity::radians_per_second_t vel) {
-  leftMainShooterMotor.setVelocity(vel);
-}
+ShooterSubsystem::ShooterSubsystem() {}
 
 void ShooterSubsystem::spinTo(units::velocity::meters_per_second_t vel) {
-  leftMainShooterMotor.setVelocity(
-    units::angular_velocity::radians_per_second_t(vel * (1_rad / (wheelDiameter / 2)))
-  );
+  flywheel.setVelocity(vel);
 }
 
 void ShooterSubsystem::stop() {
-  leftMainShooterMotor.setVelocity(0.0_tps);
+  flywheel.setVelocity(0.0_mps);
 }
 
-units::angular_velocity::radians_per_second_t ShooterSubsystem::getAngularVelocity() {
-  return leftMainShooterMotor.getVelocity();
-}
-units::velocity::meters_per_second_t ShooterSubsystem::getLinearVelocity() {
-  return leftMainShooterMotor.getVelocity() / 1_rad * wheelDiameter;
+units::velocity::meters_per_second_t ShooterSubsystem::getVelocity() {
+  return flywheel.getVelocity();
 }
 
 

--- a/src/main/include/Constants.h
+++ b/src/main/include/Constants.h
@@ -96,29 +96,28 @@ namespace positionControllerConstants
 } // namespace positionControllerConstants
 
 namespace shooterSubsystemConstants {
-  const int leftShooterMotorID  = 7,
-      rightShooterMotorID = 8;
+  const int flywheelMotorID  = 7;
 
-  const rmb::SparkMaxVelocityController<units::radians>::PIDConfig
-    motorPIDConfig{
+  const rmb::SparkMaxVelocityController<units::meters>::PIDConfig
+    flywheelPIDConfig{
         /* p */ 0.0, /* i */ 0.0, /* d */ 0.0, /* f */ 0.0,
         /* iZone */ 0.0, /* iMaxAccumulator */ 0.0,
         /* maxOutput */ 1.0, /* minOutput */ -1.0,
 
         /* SmartMotion config */
         /* usingSmartMotion */ true,
-        /* maxVelocity */ 100_tps, /* minVelocity */ 0_tps,
-        /* maxAccel */ 10_rad_per_s_sq,
-        /* allowedErr */ 0.01_tps,
+        /* maxVelocity */ 100_mps, /* minVelocity */ 0_mps,
+        /* maxAccel */ 10_mps_sq,
+        /* allowedErr */ 0.01_mps,
         /* accelStrategy */ rev::SparkMaxPIDController::AccelStrategy::kSCurve
     };
 
-  const rmb::SimpleMotorFeedforward<units::radians>
-    motorFeedforward(rmb::SimpleMotorFeedforward<units::radians>::Ks_t(0.10973),
-                     rmb::SimpleMotorFeedforward<units::radians>::Kv_t(3.15920),
-                     rmb::SimpleMotorFeedforward<units::radians>::Ka_t(0.30746));
+  const rmb::SimpleMotorFeedforward<units::meters>
+    flywheelFeedforward(rmb::SimpleMotorFeedforward<units::meters>::Ks_t(0.10973),
+                     rmb::SimpleMotorFeedforward<units::meters>::Kv_t(3.15920),
+                     rmb::SimpleMotorFeedforward<units::meters>::Ka_t(0.30746));
 
-  const auto motorConversion = 
-       rmb::SparkMaxVelocityController<units::radians>::ConversionUnit_t(1_rad / 1_rad);
+  const auto flywheelConversion = 
+       rmb::SparkMaxVelocityController<units::meters>::ConversionUnit_t(1_m / 1_rad);
 
 }

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -25,7 +25,7 @@ public:
 private:
 
   void ConfigureButtonBindings();
-  ShooterSubsystem  shooterSubsystem{1_m};
+  ShooterSubsystem  shooterSubsystem;
   ClimberSubsystem  climberSubsystem;
   DriveSubsystem    driveSubsystem;
   IntakeSubsystem   intakeSubsystem;

--- a/src/main/include/shooter/ShooterSubsystem.h
+++ b/src/main/include/shooter/ShooterSubsystem.h
@@ -14,38 +14,26 @@
 
 class ShooterSubsystem : public frc2::SubsystemBase {
  public:
-  ShooterSubsystem() = delete;
-  ShooterSubsystem(const units::meter_t wheelDiameter = 1_m);
+  ShooterSubsystem();
 
   /**
    * Will be called periodically whenever the CommandScheduler runs.
    */
   void Periodic() override;
 
-  void spinTo(units::angular_velocity::radians_per_second_t vel);
   void spinTo(units::velocity::meters_per_second_t vel);
 
   void stop();
 
-  units::angular_velocity::radians_per_second_t getAngularVelocity();
-  units::velocity::meters_per_second_t getLinearVelocity();
+  units::velocity::meters_per_second_t getVelocity();
 
  private:
 
-  const units::meter_t wheelDiameter;
-
-  rmb::SparkMaxVelocityController<units::radians>::Follower rightShooterMotor {
-    shooterSubsystemConstants::rightShooterMotorID,
-    rev::CANSparkMax::MotorType::kBrushless,
-    false
-  };
-
-  rmb::SparkMaxVelocityController<units::radians> leftMainShooterMotor{
-    shooterSubsystemConstants::leftShooterMotorID,
-    shooterSubsystemConstants::motorPIDConfig,
-    shooterSubsystemConstants::motorConversion,
-    rmb::noFeedforward<units::radians>,
-    {rightShooterMotor}
+  rmb::SparkMaxVelocityController<units::meters> flywheel{
+    shooterSubsystemConstants::flywheelMotorID,
+    shooterSubsystemConstants::flywheelPIDConfig,
+    shooterSubsystemConstants::flywheelConversion,
+    shooterSubsystemConstants::flywheelFeedforward
   };
 
   // Components (e.g. motor controllers and sensors) should generally be


### PR DESCRIPTION
I swapped the flywheel of the shooter over to meters per second as opposed to radians per second since we will only need to use the linear velocity unless you see reason to leave it as radians.