### PR TITLE
alternateEncoderFix

### DIFF
--- a/lib/src/motorcontrol/sparkmax/SparkMaxPositionController.cpp
+++ b/lib/src/motorcontrol/sparkmax/SparkMaxPositionController.cpp
@@ -26,8 +26,8 @@ rmb::SparkMaxPositionController<U>::SparkMaxPositionController(
     : sparkMax(deviceID, rev::CANSparkMax::MotorType::kBrushless),
       sparkMaxEncoder(
         alternateEncoder ? 
-          std::unique_ptr<rev::RelativeEncoder>(std::make_unique<rev::SparkMaxRelativeEncoder>(sparkMax.GetEncoder())) :
-          std::unique_ptr<rev::RelativeEncoder>(std::make_unique<rev::SparkMaxAlternateEncoder>(sparkMax.GetAlternateEncoder(ticksPerRotation)))
+          std::unique_ptr<rev::RelativeEncoder>(std::make_unique<rev::SparkMaxAlternateEncoder>(sparkMax.GetAlternateEncoder(ticksPerRotation))) :
+          std::unique_ptr<rev::RelativeEncoder>(std::make_unique<rev::SparkMaxRelativeEncoder>(sparkMax.GetEncoder()))
         ),
       sparkMaxPIDController(sparkMax.GetPIDController()),
       conversion(conversionFactor), feedforward(ff) {

--- a/lib/src/motorcontrol/sparkmax/SparkMaxVelocityController.cpp
+++ b/lib/src/motorcontrol/sparkmax/SparkMaxVelocityController.cpp
@@ -22,8 +22,8 @@ SparkMaxVelocityController<U>::SparkMaxVelocityController(
     : sparkMax(deviceID, rev::CANSparkMax::MotorType::kBrushless),
       sparkMaxEncoder(
         alternateEncoder ? 
-          std::unique_ptr<rev::RelativeEncoder>(std::make_unique<rev::SparkMaxRelativeEncoder>(sparkMax.GetEncoder())) :
-          std::unique_ptr<rev::RelativeEncoder>(std::make_unique<rev::SparkMaxAlternateEncoder>(sparkMax.GetAlternateEncoder(countsPerRevolution)))
+          std::unique_ptr<rev::RelativeEncoder>(std::make_unique<rev::SparkMaxAlternateEncoder>(sparkMax.GetAlternateEncoder(countsPerRevolution))) :
+          std::unique_ptr<rev::RelativeEncoder>(std::make_unique<rev::SparkMaxRelativeEncoder>(sparkMax.GetEncoder()))
         ),
       sparkMaxPIDController(sparkMax.GetPIDController()),
       conversion(conversionUnit), feedforward(ff) {


### PR DESCRIPTION
the alternateEncoder and SparkMaxEncoder construction was swapped so it was constructing an alternateEncoder when alternateEncoder was false