### PR TITLE
setFeedBackDevice

### DIFF
--- a/lib/src/motorcontrol/sparkmax/SparkMaxPositionController.cpp
+++ b/lib/src/motorcontrol/sparkmax/SparkMaxPositionController.cpp
@@ -32,7 +32,8 @@ rmb::SparkMaxPositionController<U>::SparkMaxPositionController(
       sparkMaxPIDController(sparkMax.GetPIDController()),
       conversion(conversionFactor), feedforward(ff) {
 
-  sparkMax.RestoreFactoryDefaults();
+  CHECK_REVLIB_ERROR(sparkMax.RestoreFactoryDefaults());
+  CHECK_REVLIB_ERROR(sparkMaxPIDController.SetFeedbackDevice(*sparkMaxEncoder));
 
   // configure pid consts
   CHECK_REVLIB_ERROR(sparkMaxPIDController.SetP(config.p));

--- a/lib/src/motorcontrol/sparkmax/SparkMaxVelocityController.cpp
+++ b/lib/src/motorcontrol/sparkmax/SparkMaxVelocityController.cpp
@@ -30,6 +30,7 @@ SparkMaxVelocityController<U>::SparkMaxVelocityController(
 
   sparkMax.RestoreFactoryDefaults();
 
+  CHECK_REVLIB_ERROR(sparkMaxPIDController.SetFeedbackDevice(*sparkMaxEncoder));
   CHECK_REVLIB_ERROR(sparkMaxPIDController.SetP(config.p));
   CHECK_REVLIB_ERROR(sparkMaxPIDController.SetI(config.i));
   CHECK_REVLIB_ERROR(sparkMaxPIDController.SetD(config.d));

--- a/lib/src/motorcontrol/sparkmax/SparkMaxVelocityController.cpp
+++ b/lib/src/motorcontrol/sparkmax/SparkMaxVelocityController.cpp
@@ -28,7 +28,7 @@ SparkMaxVelocityController<U>::SparkMaxVelocityController(
       sparkMaxPIDController(sparkMax.GetPIDController()),
       conversion(conversionUnit), feedforward(ff) {
 
-  sparkMax.RestoreFactoryDefaults();
+  CHECK_REVLIB_ERROR(sparkMax.RestoreFactoryDefaults());
 
   CHECK_REVLIB_ERROR(sparkMaxPIDController.SetFeedbackDevice(*sparkMaxEncoder));
   CHECK_REVLIB_ERROR(sparkMaxPIDController.SetP(config.p));


### PR DESCRIPTION
Left this out of the original implementation. This is so that the SparkMax actually uses the external sensor when applicable.