### PR TITLE
Trajectory test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,5 +177,9 @@ docs/*
 !docs/doxygen-awesome.css
 !docs/Doxyfile
 !docs/favicon.png
+!docs/favicon.png
 
 .idea/
+.cache/
+
+.project.alt.json

--- a/lib/include/rmb/math/misc.h
+++ b/lib/include/rmb/math/misc.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cmath>
+
+namespace rmb {
+
+    inline double constrain(double n, double low, double high) {
+        return fmax(fmin(n, high), low);
+    }
+
+    inline double map(double n, double start1, double start2, double stop1, double stop2, bool withinBounds = true) {
+        const double newval = (n - start1) / (stop1 - start1) * (stop2 - start2) + start2;
+        if (!withinBounds) {
+            return newval;
+        }
+        if (start2 < stop2) {
+            return constrain(newval, start2, stop2);
+        } else {
+            return constrain(newval, stop2, start2);
+        }
+    }
+}

--- a/lib/src/drive/HolonomicTrajectoryCommand.cpp
+++ b/lib/src/drive/HolonomicTrajectoryCommand.cpp
@@ -29,5 +29,6 @@ void HolonomicTrajectoryCommand::End(bool interrupted) { timer.Stop(); }
 
 bool HolonomicTrajectoryCommand::IsFinished() {
   return timer.HasElapsed(trajectory.TotalTime());
+
 }
 } // namespace rmb

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -56,10 +56,10 @@ void Robot::AutonomousInit() {
 void Robot::AutonomousPeriodic() {}
 
 void Robot::TeleopInit() {
-   frc2::CommandScheduler::GetInstance().Schedule(
-       container.getManualShooterCommand());
+//   frc2::CommandScheduler::GetInstance().Schedule(
+//       container.getManualShooterCommand());
 
-
+    container.getTeleopDriveCommand().Schedule();
 }
 
 /**

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -13,6 +13,9 @@
 
 #include <rmb/io/log.h>
 
+#include <rmb/drive/HolonomicTrajectoryCommand.h>
+#include <frc/trajectory/TrajectoryGenerator.h>
+
 void Robot::RobotInit() { 
   //turretPositionController.resetRefrence(0_rad);
   // container.shuffleBoard.ShuffleBoardInit();
@@ -67,9 +70,13 @@ void Robot::TeleopPeriodic() {}
 /**s
  * This function is called periodically during test mode.
  */
-void Robot::TestPeriodic() {}
+void Robot::TestPeriodic() {
+    frc2::CommandScheduler::GetInstance().Run();
+}
 
-void Robot::TestInit(){}
+void Robot::TestInit() {
+
+}
 
 
 

--- a/src/main/cpp/drivetrain/TeleopDriveCommand.cpp
+++ b/src/main/cpp/drivetrain/TeleopDriveCommand.cpp
@@ -22,7 +22,7 @@ void TeleopDriveCommand::Execute() {
   double throttle = joystickSubsystem.getThrottle();
   driveSubsystem.driveCartesian(joystickSubsystem.getY() * throttle,
                                 joystickSubsystem.getX() * throttle,
-                                joystickSubsystem.getTwist());
+                                joystickSubsystem.getTwist() * throttle);
 }
 
 // Called once the command ends or is interrupted.

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -30,6 +30,7 @@ public:
 
   TeleopDriveCommand &getTeleopDriveCommand() { return teleopDriveCommand; }
   ManualShooterCommand* getManualShooterCommand() { return &manualShooterCommand; }
+
 private:
 
   void ConfigureButtonBindings();
@@ -54,5 +55,8 @@ private:
 //  TurretFindCommand turretFindCommand{ turretSubsystem, visionSubsystem };
   ManualShooterCommand manualShooterCommand{ shooterSubsystem, joystickSubsystem, turretSubsystem, storageSubsystem, hoodSubsystem };
 
+  // BEGIN Holonomic Trajectory Tests
+
+  // END
 
 };

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -47,7 +47,7 @@ private:
   IntakeExtenderSubsystem intakeExtenderSubsystem;
   IntakeSpinnerSubsystem intakeSpinnerSubsystem{intakeExtenderSubsystem};
   StorageSubsystem storageSubsystem;
-  JoystickSubsystem joystickSubsystem{0};
+  JoystickSubsystem joystickSubsystem{0, 0.2, true};
   TeleopDriveCommand teleopDriveCommand{ driveSubsystem, joystickSubsystem };
   HoodSubsystem hoodSubsystem{};
 //  ShuffleBoardSubsystem  shuffleBoard{ shooterSubsystem, joystickSubsystem, climberSubsystem, driveSubsystem, intakeExtenderSubsystem, intakeSpinnerSubsystem };

--- a/src/main/include/driverstation/JoystickSubsystem.h
+++ b/src/main/include/driverstation/JoystickSubsystem.h
@@ -6,6 +6,9 @@
 #include <frc2/command/SubsystemBase.h>
 #include <frc2/command/button/JoystickButton.h>
 
+#include <rmb/math/misc.h>
+#include <rmb/io/log.h>
+
 class JoystickSubsystem : public frc2::SubsystemBase {
 public:
   JoystickSubsystem(int port = 0, float dz = 0.1f, bool sqrTwst = false)
@@ -13,17 +16,18 @@ public:
   } // Init constructer
 
   double getX() const {
-    return std::abs(joystick.GetX()) <= deadZone
-               ? 0.0f
-               : -joystick.GetX(); // Get the Y val of the joystick, doesn't
-                                  // include values within deadzone
+      double val = std::abs(joystick.GetX()) < deadZone ? 0.0 : joystick.GetX();
+      return -1.0 * wpi::sgn(val) * rmb::map(std::abs(val),
+                                             deadZone, 0.0,
+                                             1.0, 1.0, false);
+
   }
 
   double getY() const {
-    return std::abs(joystick.GetY()) <= deadZone
-               ? 0.0f
-               : -joystick.GetY(); // Get the Y val of the joystick, doesn't
-                                  // include values within deadzone
+      double val = std::abs(joystick.GetY()) < deadZone ? 0.0 : joystick.GetY();
+      return -1.0 * wpi::sgn(val) * rmb::map(std::abs(val),
+                                             deadZone, 0.0,
+                                             1.0, 1.0, false);
   }
 
   inline double getXRaw() const { // Gets Joystick Raw values witout deadzone
@@ -48,15 +52,20 @@ public:
   }
 
   double getTwist() const { // Gets joystick twist/rotation
-    double twist = joystick.GetTwist();
-    if (std::abs(twist) <= deadZone) {
-      twist = 0.0;
-    } else {
-      if (squareTwist) {
-        twist = std::pow(twist, 2);
-        twist = (joystick.GetTwist() >= 0) ? twist : -twist;
-      }
-    } // If none, then it just returns twist
+
+    double twist = std::abs(joystick.GetTwist()) < deadZone ? 0.0 : joystick.GetTwist();
+
+    wpi::outs() << "raw twist: " << twist;
+    if(squareTwist) {
+        // -1 * 0.09 -> -0.09
+        //twist = wpi::sgn(twist) * std::pow(twist, 2);
+    }
+
+    // -1 *
+    twist = wpi::sgn(twist) * rmb::map(std::abs(twist), deadZone, 0.0, 1.0, 1.0, false);
+
+
+    wpi::outs() << " twist: " << twist << wpi::endl;
     return twist;
   }
 


### PR DESCRIPTION
The issue with the drivetrain was that the twist value wasn't being multiplied by the throttle. **SOOO** when the throttle was at zero (unbeknownst to you and me), the twist seemed to be working at full speed and everything else was zeroed.

**Also**, a while back, Wesley requested some joystick changes. Before, when the joystick exited the deadzone, the joystick value would jump to the raw position that it was at, causing a sudden change from 0 to kinda fast. I fixed this by creating a map function that makes the deadzone 0.0 for the joystick and maps the remaining space inbetween deadzone and 1.0 to 0.0 and 1.0.

Thus, I deleted a good portion of Sam's joystick implementation. 