### PR TITLE
fix joystick and update math util functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,5 @@ docs/*
 .cache/
 
 .project.alt.json
+
+compile_commands.json

--- a/lib/include/rmb/math/misc.h
+++ b/lib/include/rmb/math/misc.h
@@ -1,22 +1,45 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 
 namespace rmb {
 
-    inline double constrain(double n, double low, double high) {
-        return fmax(fmin(n, high), low);
+    /**
+     * Checks if a value is within raneg
+     * @param n the value to check for position in range
+     * @param lo the lower bound of the range
+     * @param hi the upper bound of the range
+     * @return whether or not the value is in between lo and hi. true if in between.
+     */
+    template <typename T>
+    inline bool withinRange(T n, T lo, T hi) {
+        if (hi < lo) 
+            std::swap(lo, hi);
+        
+        return n > lo && n < hi;
     }
 
-    inline double map(double n, double start1, double start2, double stop1, double stop2, bool withinBounds = true) {
-        const double newval = (n - start1) / (stop1 - start1) * (stop2 - start2) + start2;
+    /**
+     * Map a number of one range of numbers to another range of numbers
+     * @param n the value to be mapped
+     * @param start1 the lower bound of the current range of n
+     * @param stop1  the upper bound of the current range of n
+     * @param start2 the lower bound of the destination range of n
+     * @param stop2  the upper bound of the destination range of n
+     * @param withinBounds 
+     * @return n mapped to range [start2, stop2]
+     */
+    template <typename T>
+    inline T map(T n, T start1,  T stop1, T start2, T stop2, bool withinBounds = true) {
+        const T newval = (n - start1) / (stop1 - start1) * (stop2 - start2) + start2;
         if (!withinBounds) {
             return newval;
         }
         if (start2 < stop2) {
-            return constrain(newval, start2, stop2);
+            return std::clamp(newval, start2, stop2);
         } else {
-            return constrain(newval, stop2, start2);
+            return std::clamp(newval, stop2, start2);
         }
     }
 }

--- a/src/main/cpp/driverstation/JoystickSubsystem.cpp
+++ b/src/main/cpp/driverstation/JoystickSubsystem.cpp
@@ -1,0 +1,37 @@
+#include "driverstation/JoystickSubsystem.h"
+
+double JoystickSubsystem::getX() const {  
+    double val = std::abs(joystick.GetX()) < deadZone ? 0.0 : joystick.GetX();
+    return coefficients.x * wpi::sgn(val) * rmb::map(std::abs(val),
+                                            deadZone, 1.0,
+                                            0.0, 1.0, false);
+}
+
+double JoystickSubsystem::getY() const {
+      double val = std::abs(joystick.GetY()) < deadZone ? 0.0 : joystick.GetY();
+      return coefficients.y * wpi::sgn(val) * rmb::map(std::abs(val),
+                                             deadZone, 1.0,
+                                             0.0, 1.0, false);
+}
+
+double JoystickSubsystem::getTwist() const {
+
+    double twist = std::abs(joystick.GetTwist()) < deadZone ? 0.0 : joystick.GetTwist();
+   
+    twist = coefficients.twist * wpi::sgn(twist) * rmb::map(std::abs(twist), deadZone, 1.0, 0.0, 1.0, false);
+
+    return twist;
+}
+
+double JoystickSubsystem::getThrottle() const { 
+    return -(joystick.GetThrottle() - 1) / 2; 
+}
+
+frc2::JoystickButton
+JoystickSubsystem::getButton(int button) {
+    return frc2::JoystickButton(&joystick, button);
+}
+
+bool JoystickSubsystem::buttonPressed(int button) {
+    return joystick.GetRawButton(button);
+}

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -47,7 +47,7 @@ private:
   IntakeExtenderSubsystem intakeExtenderSubsystem;
   IntakeSpinnerSubsystem intakeSpinnerSubsystem{intakeExtenderSubsystem};
   StorageSubsystem storageSubsystem;
-  JoystickSubsystem joystickSubsystem{0, 0.2, true};
+  JoystickSubsystem joystickSubsystem{0, 0.2};
   TeleopDriveCommand teleopDriveCommand{ driveSubsystem, joystickSubsystem };
   HoodSubsystem hoodSubsystem{};
 //  ShuffleBoardSubsystem  shuffleBoard{ shooterSubsystem, joystickSubsystem, climberSubsystem, driveSubsystem, intakeExtenderSubsystem, intakeSpinnerSubsystem };

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -47,7 +47,7 @@ private:
   IntakeExtenderSubsystem intakeExtenderSubsystem;
   IntakeSpinnerSubsystem intakeSpinnerSubsystem{intakeExtenderSubsystem};
   StorageSubsystem storageSubsystem;
-  JoystickSubsystem joystickSubsystem{0, 0.2};
+  JoystickSubsystem joystickSubsystem{0, 0.2, {-1.0, -1.0, 1.0}};
   TeleopDriveCommand teleopDriveCommand{ driveSubsystem, joystickSubsystem };
   HoodSubsystem hoodSubsystem{};
 //  ShuffleBoardSubsystem  shuffleBoard{ shooterSubsystem, joystickSubsystem, climberSubsystem, driveSubsystem, intakeExtenderSubsystem, intakeSpinnerSubsystem };

--- a/src/main/include/driverstation/JoystickSubsystem.h
+++ b/src/main/include/driverstation/JoystickSubsystem.h
@@ -11,23 +11,22 @@
 
 class JoystickSubsystem : public frc2::SubsystemBase {
 public:
-  JoystickSubsystem(int port = 0, float dz = 0.1f, bool sqrTwst = false)
-      : joystick(port), deadZone(dz), squareTwist(sqrTwst) {
-  } // Init constructer
+  JoystickSubsystem(int port = 0, double dz = 0.1)
+      : joystick(port), deadZone(dz) {}
 
   double getX() const {
       double val = std::abs(joystick.GetX()) < deadZone ? 0.0 : joystick.GetX();
       return -1.0 * wpi::sgn(val) * rmb::map(std::abs(val),
-                                             deadZone, 0.0,
-                                             1.0, 1.0, false);
+                                             deadZone, 1.0,
+                                             0.0, 1.0, false);
 
   }
 
   double getY() const {
       double val = std::abs(joystick.GetY()) < deadZone ? 0.0 : joystick.GetY();
       return -1.0 * wpi::sgn(val) * rmb::map(std::abs(val),
-                                             deadZone, 0.0,
-                                             1.0, 1.0, false);
+                                             deadZone, 1.0,
+                                             0.0, 1.0, false);
   }
 
   inline double getXRaw() const { // Gets Joystick Raw values witout deadzone
@@ -54,18 +53,9 @@ public:
   double getTwist() const { // Gets joystick twist/rotation
 
     double twist = std::abs(joystick.GetTwist()) < deadZone ? 0.0 : joystick.GetTwist();
+   
+    twist = wpi::sgn(twist) * rmb::map(std::abs(twist), deadZone, 1.0, 0.0, 1.0, false);
 
-    wpi::outs() << "raw twist: " << twist;
-    if(squareTwist) {
-        // -1 * 0.09 -> -0.09
-        //twist = wpi::sgn(twist) * std::pow(twist, 2);
-    }
-
-    // -1 *
-    twist = wpi::sgn(twist) * rmb::map(std::abs(twist), deadZone, 0.0, 1.0, 1.0, false);
-
-
-    wpi::outs() << " twist: " << twist << wpi::endl;
     return twist;
   }
 
@@ -73,6 +63,5 @@ public:
 
 private:
   frc::Joystick joystick;
-  float deadZone = 0.1f;
-  bool squareTwist = false;
+  double deadZone = 0.1f;
 };

--- a/src/main/include/driverstation/JoystickSubsystem.h
+++ b/src/main/include/driverstation/JoystickSubsystem.h
@@ -1,4 +1,4 @@
-//@notSam25
+//@notSam25. Revised by @theVerySharpFlat
 #pragma once
 
 #include <cmath>
@@ -11,57 +11,106 @@
 
 class JoystickSubsystem : public frc2::SubsystemBase {
 public:
-  JoystickSubsystem(int port = 0, double dz = 0.1)
-      : joystick(port), deadZone(dz) {}
 
-  double getX() const {
-      double val = std::abs(joystick.GetX()) < deadZone ? 0.0 : joystick.GetX();
-      return -1.0 * wpi::sgn(val) * rmb::map(std::abs(val),
-                                             deadZone, 1.0,
-                                             0.0, 1.0, false);
+  /**
+   * A struct that contains the multiplers for the joystick coefficients
+   */
+  struct JoystickCoefficients {
+    double x = 1.0; /**< The multiplier on the x value*/
+    double y = 1.0; /**< The multiplier on the y value*/
+    double twist = 1.0; /**< The multiplier on the twist value*/
+  };
 
-  }
+  JoystickSubsystem(int port = 0, double dz = 0.1, JoystickCoefficients joystickCoefficients = {1.0, 1.0, 1.0})
+      : joystick(port), deadZone(dz), coefficients(joystickCoefficients) {}
 
-  double getY() const {
-      double val = std::abs(joystick.GetY()) < deadZone ? 0.0 : joystick.GetY();
-      return -1.0 * wpi::sgn(val) * rmb::map(std::abs(val),
-                                             deadZone, 1.0,
-                                             0.0, 1.0, false);
-  }
+  /**
+   * Get the X value of the joystick
+   * @return the displacement about the x axis of the joystick between -1.0 and 1.0/ 
+   *         If the value is within the deadzone, it is set to zero.
+   *         If nonzero the output of this function is then mapped from 
+   *         the range [deadzone, 1.0] to [0.0, 1.0].
+   *         The rationale for this mapping comes from the fact that when not
+   *         mapped, the moment the joystick exits the deadzone, it would return
+   *         the raw position of the joystick and the motor connected to the joystick
+   *         would jump from zero to moving at a much faster speed. When it is mapped,
+   *         the joystick zeroes at the deadzone and increases linearly to 1.0
+   */
+  double getX() const;
 
-  inline double getXRaw() const { // Gets Joystick Raw values witout deadzone
+  /**
+   * Get the Y value of the joystick
+   * @return the displacement about the y axis of the joystick between -1.0 and 1.0
+   *         If the value is within the deadzone, it is set to zero.
+   * @see getX() getTwist()
+   */
+  double getY() const;
+
+  /**
+   * Get the twist value of the joystick between -1.0 and 1.0
+   * @return the displacement about the twist axis of the joystick
+   *         If the value is within the deadzone, it is set to zero.
+   * @see getX() getY()
+   */
+  double getTwist() const;
+
+  /**
+   * Get the throttle value between 0.0 and 1.0
+   * @return the throttle value on the joystick
+   */
+  double getThrottle() const;
+
+  /**
+   * Get the raw JoysticButton from the button code
+   * @param button The target button code
+   * @return the raw frc::JoystickButton with ID "button"
+   */
+  frc2::JoystickButton getButton(int button);
+  
+  /**
+   * Check if a button is pressed
+   * @param button the ID of the target button on the joystick
+   * @return whether or not the button is pressed. true if pressed.
+   */
+  bool buttonPressed(int button);
+
+
+  /**
+   * Get the raw x value directly from the joystick without parsing
+   * @return The raw x value without deadzones
+   */
+  inline double getXRaw() const {
     return joystick.GetX();
   }
 
-  inline double getYRaw() const { // Gets Joystick Raw values witout deadzone
+
+  /**
+   * Get the raw y value directly from the joystick without parsing
+   * @return The raw y value without deadzones
+   */
+  inline double getYRaw() const {
     return joystick.GetY();
   }
 
+  /**
+   * Get the raw twist value directly from the joystick without parsing
+   * @return The raw twist value without deadzones
+   */
   inline double getTwistRaw() const {
     return joystick.GetTwist();
   }
-  frc2::JoystickButton
-  getButton(int button) { // Gets the button passed through the enum
-    return frc2::JoystickButton(&joystick, button);
+
+  /**
+   * Get the raw throttle value directly from the joystick without parsing
+   * @return The raw throttle value without deadzones
+   */
+  inline double getThrottleRaw() const {
+    return joystick.GetThrottle();
   }
-  
-  bool
-  buttonPressed(int button) { // Gets the button passed through the enum
-    return joystick.GetRawButton(button);
-  }
-
-  double getTwist() const { // Gets joystick twist/rotation
-
-    double twist = std::abs(joystick.GetTwist()) < deadZone ? 0.0 : joystick.GetTwist();
-   
-    twist = wpi::sgn(twist) * rmb::map(std::abs(twist), deadZone, 1.0, 0.0, 1.0, false);
-
-    return twist;
-  }
-
-  double getThrottle() const { return -(joystick.GetThrottle() - 1) / 2; }
 
 private:
   frc::Joystick joystick;
   double deadZone = 0.1f;
+
+  JoystickCoefficients coefficients;
 };


### PR DESCRIPTION
Moved math functions to templates, got rid of square twist commented code, made deadzones of type double, rearranged arguments for rmb::map so that they make more sense (to me).